### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
         version: [24]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.version }}
       - run: npm install

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install ESLint Dependencies
         run: |
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/example-repometrics.yml
+++ b/.github/workflows/example-repometrics.yml
@@ -13,9 +13,9 @@ jobs:
       GHE_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GHE_METRICS_DEPTH: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20.x
       - name: npm setup
@@ -23,7 +23,7 @@ jobs:
       - name: exec orgmetrics
         run: npx node app.js
       - name: Save orgmetrics.json artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: repometrics
           path: repometrics.json

--- a/.github/workflows/orgmetrics.yml
+++ b/.github/workflows/orgmetrics.yml
@@ -15,9 +15,9 @@ jobs:
       GHE_METRICS_DEPTH: ${{ vars.GHE_METRICS_DEPTH }}
       GHE_ORG_LIST: ${{ vars.GHE_ORG_LIST }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20.x
       - name: npm setup
@@ -25,7 +25,7 @@ jobs:
       - name: exec orgmetrics
         run: npx node app.js
       - name: Save orgmetrics.json artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: orgmetrics
           path: orgmetrics.json


### PR DESCRIPTION
Pin all GitHub Actions references from mutable tags to immutable full commit SHAs for improved supply chain security. Tags are preserved as inline comments for readability.